### PR TITLE
Fix endianness issue in ByteBufferInputStream

### DIFF
--- a/src/main/java/org/indunet/fastproto/io/ByteBufferInputStream.java
+++ b/src/main/java/org/indunet/fastproto/io/ByteBufferInputStream.java
@@ -329,8 +329,8 @@ public final class ByteBufferInputStream extends ByteBufferIOStream {
             value |= ((byteBuffer.get(o + 2) & 0xFFL) << 40);
             value |= ((byteBuffer.get(o + 3) & 0xFFL) << 32);
 
-            value |= ((byteBuffer.get(o + 5) & 0xFFL) << 16);
             value |= ((byteBuffer.get(o + 4) & 0xFFL) << 24);
+            value |= ((byteBuffer.get(o + 5) & 0xFFL) << 16);
             value |= ((byteBuffer.get(o + 6) & 0xFFL) << 8);
             value |= (byteBuffer.get(o + 7) & 0xFFL);
         }


### PR DESCRIPTION
## Summary
- fix wrong byte index order for BIG endian case when reading doubles

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6841f433ff088324886e3243ada14e2e