### PR TITLE
Fix inaccurate offset comment

### DIFF
--- a/src/main/java/org/indunet/fastproto/io/ByteBuffer.java
+++ b/src/main/java/org/indunet/fastproto/io/ByteBuffer.java
@@ -102,7 +102,7 @@ public final class ByteBuffer {
     public int reverse(int offset) {
         if (offset >= 0) {
             return offset;
-        } else if (this.fixed) {    // offset less than 0 and non-fixed.
+        } else if (this.fixed) {    // offset < 0 on fixed-length buffer.
             int o = this.bytes.length + offset;
 
             if (o >= 0) {


### PR DESCRIPTION
## Summary
- clarify offset comment for reverse addressing in `ByteBuffer`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6841f647c30883248603d4252744b364