### PR TITLE
Fix variable name in BoolArrayCodecTest

### DIFF
--- a/src/test/java/org/indunet/fastproto/codec/BoolArrayCodecTest.java
+++ b/src/test/java/org/indunet/fastproto/codec/BoolArrayCodecTest.java
@@ -50,9 +50,9 @@ public class BoolArrayCodecTest {
     public void testEncode1() {
         byte[] expected = new byte[] {(byte) 0b1010_1010};
         byte[] actual = new byte[1];
-        boolean[] datas = new boolean[] {true, false, true, false, true, false, true, false};
+        boolean[] data = new boolean[] {true, false, true, false, true, false, true, false};
 
-        codec.encode(mock(0, 0, 8, BitOrder.MSB_0), new ByteBufferOutputStream(actual), datas);
+        codec.encode(mock(0, 0, 8, BitOrder.MSB_0), new ByteBufferOutputStream(actual), data);
         assertArrayEquals(expected, actual);
     }
 


### PR DESCRIPTION
## Summary
- rename `datas` variable to `data` inside `BoolArrayCodecTest.testEncode1`

## Testing
- `mvn -q test` *(fails: Missing dependency 'object scala in compiler mirror')*

------
https://chatgpt.com/codex/tasks/task_e_6841f5e45e588324b2a8a11f6e2bcd94