### PR TITLE
Add ByteBufferInputStream double read test

### DIFF
--- a/src/test/java/org/indunet/fastproto/io/ByteBufferInputStreamTest.java
+++ b/src/test/java/org/indunet/fastproto/io/ByteBufferInputStreamTest.java
@@ -1,0 +1,23 @@
+package org.indunet.fastproto.io;
+
+import org.indunet.fastproto.ByteOrder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link ByteBufferInputStream}.
+ */
+public class ByteBufferInputStreamTest {
+    @Test
+    public void testReadDoubleBigEndian() {
+        double expected = 3.1415926;
+        ByteBufferOutputStream output = new ByteBufferOutputStream();
+        output.writeDouble(2, ByteOrder.BIG, expected);
+
+        ByteBufferInputStream input = new ByteBufferInputStream(output.toByteBuffer());
+        double actual = input.readDouble(2, ByteOrder.BIG);
+
+        assertEquals(expected, actual, 0.000001);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ByteBufferInputStreamTest` verifying reading of a double in big-endian order

## Testing
- `mvn -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 test`

------
https://chatgpt.com/codex/tasks/task_e_6841f655574c8324b17ebc4bf5ec289b