### PR TITLE
完善CRC计算单元测试

### DIFF
--- a/src/test/java/org/indunet/fastproto/checksum/CRC16Test.java
+++ b/src/test/java/org/indunet/fastproto/checksum/CRC16Test.java
@@ -58,4 +58,25 @@ public class CRC16Test {
 
         assertEquals(expectedCRC, crc16.calculate(data));
     }
+
+    @Test
+    public void testCustomPolynomial() {
+        CRC16 custom = new CRC16();
+        custom.setPolynomial(CRC16.CRC16_CCITT_POLYNOMIAL);
+        custom.setInitialValue(CRC16.CRC16_CCITT_INITIAL_VALUE);
+        byte[] data = {0x31, 0x32, 0x33, 0x34, 0x35};
+        int expectedCRC = 0x44BF;
+
+        assertEquals(expectedCRC, custom.calculate(data));
+    }
+
+    @Test
+    public void testSetInitialValue() {
+        CRC16 custom = new CRC16();
+        custom.setInitialValue(CRC16.CRC16_MODBUS_INITIAL_VALUE);
+        byte[] data = {0x31, 0x32, 0x33, 0x34, 0x35};
+        int expectedCRC = 0xA471;
+
+        assertEquals(expectedCRC, custom.calculate(data));
+    }
 }

--- a/src/test/java/org/indunet/fastproto/checksum/CRC32Test.java
+++ b/src/test/java/org/indunet/fastproto/checksum/CRC32Test.java
@@ -59,4 +59,42 @@ public class CRC32Test {
 
         assertEquals(expectedCRC, crc32.calculate(data));
     }
+
+    @Test
+    public void testCustomPolynomial() {
+        CRC32 custom = new CRC32(0x1EDC6F41, CRC32.DEFAULT_INITIAL_VALUE);
+        byte[] data = {0x31, 0x32, 0x33, 0x34, 0x35};
+        int expectedCRC = 0x18D12335;
+
+        assertEquals(expectedCRC, custom.calculate(data));
+    }
+
+    @Test
+    public void testCustomInitialValue() {
+        CRC32 custom = new CRC32(0x1EDC6F41, 0x00000000);
+        byte[] data = {0x31, 0x32, 0x33, 0x34, 0x35};
+        int expectedCRC = 0xA25CAAFF;
+
+        assertEquals(expectedCRC, custom.calculate(data));
+    }
+
+    @Test
+    public void testSetPolynomial() {
+        CRC32 custom = new CRC32();
+        custom.setPolynomial(0x1EDC6F41);
+        byte[] data = {0x31, 0x32, 0x33, 0x34, 0x35};
+        int expectedCRC = 0x18D12335;
+
+        assertEquals(expectedCRC, custom.calculate(data));
+    }
+
+    @Test
+    public void testSetInitialValue() {
+        CRC32 custom = new CRC32();
+        custom.setInitialValue(0x00000000);
+        byte[] data = {0x31, 0x32, 0x33, 0x34, 0x35};
+        int expectedCRC = 0xF22832FE;
+
+        assertEquals(expectedCRC, custom.calculate(data));
+    }
 }

--- a/src/test/java/org/indunet/fastproto/checksum/CRC8Test.java
+++ b/src/test/java/org/indunet/fastproto/checksum/CRC8Test.java
@@ -59,4 +59,24 @@ public class CRC8Test {
 
         assertEquals(expectedCRC, crc8.calculate(data));
     }
+
+    @Test
+    public void testCustomPolynomial() {
+        CRC8 custom = new CRC8();
+        custom.setPolynomial(CRC8.CRC8_DALLAS_MAXIM_POLYNOMIAL);
+        byte[] data = {0x31, 0x32, 0x33, 0x34, 0x35};
+        int expectedCRC = 0x0E;
+
+        assertEquals(expectedCRC, custom.calculate(data));
+    }
+
+    @Test
+    public void testSetInitialValue() {
+        CRC8 custom = new CRC8();
+        custom.setInitialValue(CRC8.CRC8_CCITT_INITIAL_VALUE);
+        byte[] data = {0x31, 0x32, 0x33, 0x34, 0x35};
+        int expectedCRC = 0xF2;
+
+        assertEquals(expectedCRC, custom.calculate(data));
+    }
 }


### PR DESCRIPTION
## Summary
- 扩展CRC32测试，覆盖`setPolynomial`和`setInitialValue`
- 为CRC16和CRC8增加`setInitialValue`的测试
- 修复三个测试文件末尾缺失换行

## Testing
- `mvn -q -DskipTests=false test` *(fails: PluginResolutionException - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68451c95523c8324b981a1df50eb8d37