### PR TITLE
Add checksum pipeline and codec generator

### DIFF
--- a/src/main/java/org/indunet/fastproto/annotation/Checksum.java
+++ b/src/main/java/org/indunet/fastproto/annotation/Checksum.java
@@ -1,0 +1,18 @@
+package org.indunet.fastproto.annotation;
+
+import org.indunet.fastproto.checksum.CRCType;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation for CRC checksum field.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Checksum {
+    CRCType type();
+    /** start offset of bytes for calculation */
+    int start();
+    /** length of bytes for calculation */
+    int length();
+}

--- a/src/main/java/org/indunet/fastproto/annotation/GenerateCodec.java
+++ b/src/main/java/org/indunet/fastproto/annotation/GenerateCodec.java
@@ -1,0 +1,11 @@
+package org.indunet.fastproto.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Mark protocol class for codec generation.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface GenerateCodec {
+}

--- a/src/main/java/org/indunet/fastproto/checksum/CRCType.java
+++ b/src/main/java/org/indunet/fastproto/checksum/CRCType.java
@@ -1,0 +1,10 @@
+package org.indunet.fastproto.checksum;
+
+/**
+ * Supported CRC algorithms.
+ */
+public enum CRCType {
+    CRC8,
+    CRC16,
+    CRC32;
+}

--- a/src/main/java/org/indunet/fastproto/pipeline/Pipeline.java
+++ b/src/main/java/org/indunet/fastproto/pipeline/Pipeline.java
@@ -86,10 +86,12 @@ public abstract class Pipeline<T> {
 
     static {
         // remove unnecessary flow.
-        decodePipeline = new DecodeFlow();
+        decodePipeline = new DecodeFlow()
+                .append(org.indunet.fastproto.pipeline.checksum.ChecksumDecodeFlow.class);
 
         // remove unnecessary flow.
-        encodePipeline = new EncodeFlow();
+        encodePipeline = new EncodeFlow()
+                .append(org.indunet.fastproto.pipeline.checksum.ChecksumEncodeFlow.class);
     }
 
     protected static Pipeline<ValidatorContext> validateFlow;

--- a/src/main/java/org/indunet/fastproto/pipeline/checksum/ChecksumDecodeFlow.java
+++ b/src/main/java/org/indunet/fastproto/pipeline/checksum/ChecksumDecodeFlow.java
@@ -1,0 +1,59 @@
+package org.indunet.fastproto.pipeline.checksum;
+
+import org.indunet.fastproto.checksum.*;
+import org.indunet.fastproto.graph.Graph;
+import org.indunet.fastproto.graph.Reference;
+import org.indunet.fastproto.pipeline.FlowCode;
+import org.indunet.fastproto.pipeline.Pipeline;
+import org.indunet.fastproto.pipeline.PipelineContext;
+import org.indunet.fastproto.exception.DecodingException;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+/**
+ * Pipeline flow that verifies CRC checksum after decoding.
+ */
+public class ChecksumDecodeFlow extends Pipeline<PipelineContext> {
+    @Override
+    public void process(PipelineContext context) {
+        Graph graph = context.getGraph();
+        byte[] bytes = context.getInputStream().toByteBuffer().toBytes();
+
+        for (Reference ref : graph.getValidReferences()) {
+            Field field = ref.getField();
+            if (field.isAnnotationPresent(org.indunet.fastproto.annotation.Checksum.class)) {
+                org.indunet.fastproto.annotation.Checksum cs =
+                        field.getAnnotation(org.indunet.fastproto.annotation.Checksum.class);
+                int start = cs.start();
+                int len = cs.length() > 0 ? cs.length() : bytes.length - start;
+                byte[] segment = Arrays.copyOfRange(bytes, start, Math.min(start + len, bytes.length));
+                int expected = compute(cs.type(), segment);
+                int actual = ((Number) ref.getValue().get()).intValue();
+                if (expected != actual) {
+                    throw new DecodingException("Checksum mismatch on field " + field.getName());
+                }
+            }
+        }
+
+        this.forward(context);
+    }
+
+    private static int compute(CRCType type, byte[] data) {
+        switch (type) {
+            case CRC8:
+                return new CRC8().calculate(data);
+            case CRC16:
+                return new CRC16().calculate(data);
+            case CRC32:
+                return new CRC32().calculate(data);
+            default:
+                return 0;
+        }
+    }
+
+    @Override
+    public long getCode() {
+        return FlowCode.DECODE_FLOW_CODE;
+    }
+}

--- a/src/main/java/org/indunet/fastproto/pipeline/checksum/ChecksumEncodeFlow.java
+++ b/src/main/java/org/indunet/fastproto/pipeline/checksum/ChecksumEncodeFlow.java
@@ -1,0 +1,68 @@
+package org.indunet.fastproto.pipeline.checksum;
+
+import org.indunet.fastproto.checksum.*;
+import org.indunet.fastproto.graph.Graph;
+import org.indunet.fastproto.graph.Reference;
+import org.indunet.fastproto.pipeline.FlowCode;
+import org.indunet.fastproto.pipeline.Pipeline;
+import org.indunet.fastproto.pipeline.PipelineContext;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+/**
+ * Pipeline flow that calculates CRC checksum after encoding.
+ */
+public class ChecksumEncodeFlow extends Pipeline<PipelineContext> {
+    @Override
+    public void process(PipelineContext context) {
+        Graph graph = context.getGraph();
+        byte[] bytes = context.getOutputStream().toByteBuffer().toBytes();
+
+        for (Reference ref : graph.getValidReferences()) {
+            Field field = ref.getField();
+            if (field.isAnnotationPresent(org.indunet.fastproto.annotation.Checksum.class)) {
+                org.indunet.fastproto.annotation.Checksum cs =
+                        field.getAnnotation(org.indunet.fastproto.annotation.Checksum.class);
+                int start = cs.start();
+                int len = cs.length() > 0 ? cs.length() : bytes.length - start;
+                byte[] segment = Arrays.copyOfRange(bytes, start, Math.min(start + len, bytes.length));
+                int value = compute(cs.type(), segment);
+                ref.setValue(cast(value, field.getType()));
+                ref.encoder(context.getOutputStream());
+            }
+        }
+
+        this.forward(context);
+    }
+
+    private static int compute(CRCType type, byte[] data) {
+        switch (type) {
+            case CRC8:
+                return new CRC8().calculate(data);
+            case CRC16:
+                return new CRC16().calculate(data);
+            case CRC32:
+                return new CRC32().calculate(data);
+            default:
+                return 0;
+        }
+    }
+
+    private static Object cast(int value, Class<?> type) {
+        if (type == byte.class || type == Byte.class) {
+            return (byte) value;
+        } else if (type == short.class || type == Short.class) {
+            return (short) value;
+        } else if (type == long.class || type == Long.class) {
+            return (long) value;
+        } else {
+            return value;
+        }
+    }
+
+    @Override
+    public long getCode() {
+        return FlowCode.ENCODE_FLOW_CODE;
+    }
+}

--- a/src/main/java/org/indunet/fastproto/processor/CodecProcessor.java
+++ b/src/main/java/org/indunet/fastproto/processor/CodecProcessor.java
@@ -1,0 +1,53 @@
+package org.indunet.fastproto.processor;
+
+import org.indunet.fastproto.annotation.GenerateCodec;
+
+import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Set;
+
+/**
+ * Simple annotation processor that generates codec wrapper classes.
+ */
+@SupportedAnnotationTypes("org.indunet.fastproto.annotation.GenerateCodec")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class CodecProcessor extends AbstractProcessor {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        Elements elements = processingEnv.getElementUtils();
+        for (Element element : roundEnv.getElementsAnnotatedWith(GenerateCodec.class)) {
+            if (!(element instanceof TypeElement)) {
+                continue;
+            }
+            TypeElement type = (TypeElement) element;
+            String pkg = elements.getPackageOf(type).getQualifiedName().toString();
+            String simple = type.getSimpleName().toString();
+            String className = simple + "Codec";
+            String qualified = pkg.isEmpty() ? className : pkg + "." + className;
+            try {
+                JavaFileObject file = processingEnv.getFiler().createSourceFile(qualified, type);
+                try (Writer writer = file.openWriter()) {
+                    writer.write("package " + pkg + ";\n\n");
+                    writer.write("public class " + className + " {\n");
+                    writer.write("    public static " + simple + " decode(byte[] bytes) {\n");
+                    writer.write("        return org.indunet.fastproto.FastProto.decode(bytes, " + simple + ".class);\n");
+                    writer.write("    }\n");
+                    writer.write("    public static byte[] encode(" + simple + " obj) {\n");
+                    writer.write("        return org.indunet.fastproto.FastProto.encode(obj);\n");
+                    writer.write("    }\n");
+                    writer.write("}\n");
+                }
+            } catch (IOException e) {
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, e.getMessage());
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add `Checksum` annotation and `CRCType` enum
- implement checksum encode/decode flows
- wire new flows into main pipeline
- provide `GenerateCodec` annotation with annotation processor

## Testing
- `mvn -q test` *(fails: Plugin resolution exception due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684891812fdc832481191ddcdbd694aa