### PR TITLE
Add checksum annotation and utilities

### DIFF
--- a/src/main/java/org/indunet/fastproto/annotation/Checksum.java
+++ b/src/main/java/org/indunet/fastproto/annotation/Checksum.java
@@ -1,0 +1,33 @@
+package org.indunet.fastproto.annotation;
+
+import org.indunet.fastproto.ByteOrder;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for checksum validation.
+ * It can be used together with UInt16Type or UInt32Type to mark
+ * a field storing CRC value.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Checksum {
+    /** Start offset of the data for CRC calculation. */
+    int start();
+
+    /** Length of the data for CRC calculation. */
+    int length();
+
+    /** Checksum algorithm. */
+    Type type() default Type.CRC16;
+
+    /** Byte order when storing checksum value. */
+    ByteOrder byteOrder() default ByteOrder.LITTLE;
+
+    enum Type {
+        CRC16, CRC32
+    }
+}

--- a/src/main/java/org/indunet/fastproto/checksum/ChecksumUtils.java
+++ b/src/main/java/org/indunet/fastproto/checksum/ChecksumUtils.java
@@ -1,0 +1,24 @@
+package org.indunet.fastproto.checksum;
+
+/** Utility methods for checksum calculation. */
+public class ChecksumUtils {
+    public static int crc16(byte[] data) {
+        return new CRC16().calculate(data);
+    }
+
+    public static int crc32(byte[] data) {
+        return new CRC32().calculate(data);
+    }
+
+    /** Calculate checksum for specific range. */
+    public static long calculate(byte[] data, int start, int length, org.indunet.fastproto.annotation.Checksum.Type type) {
+        byte[] slice = new byte[length];
+        System.arraycopy(data, start, slice, 0, length);
+        switch (type) {
+            case CRC32:
+                return crc32(slice) & 0xFFFFFFFFL;
+            default:
+                return crc16(slice) & 0xFFFF;
+        }
+    }
+}

--- a/src/test/java/org/indunet/fastproto/checksum/ChecksumUtilsTest.java
+++ b/src/test/java/org/indunet/fastproto/checksum/ChecksumUtilsTest.java
@@ -1,0 +1,40 @@
+package org.indunet.fastproto.checksum;
+
+import org.indunet.fastproto.ByteOrder;
+import org.indunet.fastproto.annotation.Checksum;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ChecksumUtilsTest {
+    @Test
+    public void testCrc16LittleAndBig() {
+        byte[] data = {0x31,0x32,0x33,0x34,0x35};
+        int crc = CRC16.CRC16_IBM_INITIAL_VALUE;
+        crc = new CRC16().calculate(data);
+        byte[] little = {(byte) crc, (byte) (crc >>> 8)};
+        byte[] big = {(byte) (crc >>> 8), (byte) crc};
+        assertEquals(0xA455, crc);
+        assertArrayEquals(new byte[]{(byte)0x55,(byte)0xA4}, little);
+        assertArrayEquals(new byte[]{(byte)0xA4,(byte)0x55}, big);
+    }
+
+    @Test
+    public void testCrc32LittleAndBig() {
+        byte[] data = {0x31,0x32,0x33,0x34,0x35};
+        int crc = new CRC32().calculate(data);
+        byte[] little = {(byte)crc,(byte)(crc>>>8),(byte)(crc>>>16),(byte)(crc>>>24)};
+        byte[] big = {(byte)(crc>>>24),(byte)(crc>>>16),(byte)(crc>>>8),(byte)crc};
+        assertEquals(0xCBF53A1C, crc);
+        assertArrayEquals(new byte[]{(byte)0x1C,(byte)0x3A,(byte)0xF5,(byte)0xCB}, little);
+        assertArrayEquals(new byte[]{(byte)0xCB,(byte)0xF5,(byte)0x3A,(byte)0x1C}, big);
+    }
+
+    @Test
+    public void testCalculateRange() {
+        byte[] data = {1,2,3,4,5};
+        long crc16 = ChecksumUtils.calculate(data,0,5, Checksum.Type.CRC16);
+        long crc32 = ChecksumUtils.calculate(data,0,5, Checksum.Type.CRC32);
+        assertEquals(new CRC16().calculate(data) & 0xFFFF, crc16);
+        assertEquals(new CRC32().calculate(data) & 0xFFFFFFFFL, crc32);
+    }
+}


### PR DESCRIPTION
## Summary
- add `@Checksum` annotation to mark CRC fields
- add `ChecksumUtils` for calculating CRC16/CRC32
- test CRC utilities for both endian orders

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68582858e83c8324b12418f2b9aabf09