### PR TITLE
Add ChecksumFlow to default pipeline chain

### DIFF
--- a/src/main/java/org/indunet/fastproto/annotation/Checksum.java
+++ b/src/main/java/org/indunet/fastproto/annotation/Checksum.java
@@ -1,0 +1,32 @@
+package org.indunet.fastproto.annotation;
+
+import org.indunet.fastproto.ByteOrder;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for checksum validation.
+ * It can be used together with UInt16Type or UInt32Type to mark
+ * a field storing CRC value.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Checksum {
+    /** Start offset of the data for CRC calculation. */
+    int offset();
+
+    /** Checksum algorithm. */
+    Type type() default Type.CRC16;
+
+    /** Byte order when storing checksum value. */
+    ByteOrder byteOrder() default ByteOrder.LITTLE;
+
+    enum Type {
+        CRC8,
+        CRC16,
+        CRC32
+    }
+}

--- a/src/main/java/org/indunet/fastproto/checksum/ChecksumUtils.java
+++ b/src/main/java/org/indunet/fastproto/checksum/ChecksumUtils.java
@@ -1,0 +1,29 @@
+package org.indunet.fastproto.checksum;
+
+/** Utility methods for checksum calculation. */
+public class ChecksumUtils {
+    public static int crc8(byte[] data) {
+        return new CRC8().calculate(data);
+    }
+    public static int crc16(byte[] data) {
+        return new CRC16().calculate(data);
+    }
+
+    public static int crc32(byte[] data) {
+        return new CRC32().calculate(data);
+    }
+
+    /** Calculate checksum for specific range. */
+    public static long calculate(byte[] data, int offset, int length, org.indunet.fastproto.annotation.Checksum.Type type) {
+        byte[] slice = new byte[length];
+        System.arraycopy(data, offset, slice, 0, length);
+        switch (type) {
+            case CRC32:
+                return crc32(slice) & 0xFFFFFFFFL;
+            case CRC8:
+                return crc8(slice) & 0xFF;
+            default:
+                return crc16(slice) & 0xFFFF;
+        }
+    }
+}

--- a/src/main/java/org/indunet/fastproto/pipeline/ChecksumFlow.java
+++ b/src/main/java/org/indunet/fastproto/pipeline/ChecksumFlow.java
@@ -1,0 +1,111 @@
+package org.indunet.fastproto.pipeline;
+
+import lombok.val;
+import org.indunet.fastproto.ByteOrder;
+import org.indunet.fastproto.annotation.Checksum;
+import org.indunet.fastproto.annotation.UInt16Type;
+import org.indunet.fastproto.annotation.UInt32Type;
+import org.indunet.fastproto.annotation.UInt8Type;
+import org.indunet.fastproto.checksum.ChecksumUtils;
+import org.indunet.fastproto.exception.DecodingException;
+import org.indunet.fastproto.graph.Reference;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+public class ChecksumFlow extends Pipeline<PipelineContext> {
+    @Override
+    public void process(PipelineContext context) {
+        val graph = context.getGraph();
+        if (graph == null) {
+            this.forward(context);
+            return;
+        }
+        List<Reference> refs = graph.getValidReferences();
+        if (context.getOutputStream() != null) {
+            byte[] bytes = context.getOutputStream().toByteBuffer().toBytes();
+            for (Reference r : refs) {
+                Field f = r.getField();
+                Checksum c = f.getAnnotation(Checksum.class);
+                if (c != null) {
+                    int crcOffset = getFieldOffset(f);
+                    int length = crcOffset - c.offset();
+                    long crc = ChecksumUtils.calculate(bytes, c.offset(), length, c.type());
+                    writeChecksum(context, crcOffset, crc, c);
+                }
+            }
+        } else if (context.getInputStream() != null) {
+            byte[] bytes = context.getInputStream().toByteBuffer().toBytes();
+            for (Reference r : refs) {
+                Field f = r.getField();
+                Checksum c = f.getAnnotation(Checksum.class);
+                if (c != null) {
+                    int crcOffset = getFieldOffset(f);
+                    int length = crcOffset - c.offset();
+                    long crc = ChecksumUtils.calculate(bytes, c.offset(), length, c.type());
+                    long actual = readChecksum(bytes, crcOffset, c);
+                    if (actual != crc) {
+                        throw new DecodingException("Checksum validation failed");
+                    }
+                }
+            }
+        }
+        this.forward(context);
+    }
+
+    private int getFieldOffset(Field field) {
+        if (field.isAnnotationPresent(UInt8Type.class)) {
+            return field.getAnnotation(UInt8Type.class).offset();
+        } else if (field.isAnnotationPresent(UInt16Type.class)) {
+            return field.getAnnotation(UInt16Type.class).offset();
+        } else if (field.isAnnotationPresent(UInt32Type.class)) {
+            return field.getAnnotation(UInt32Type.class).offset();
+        }
+        return 0;
+    }
+
+    private void writeChecksum(PipelineContext ctx, int offset, long crc, Checksum c) {
+        switch (c.type()) {
+            case CRC8:
+                ctx.getOutputStream().writeUInt8(offset, (int) crc);
+                break;
+            case CRC16:
+                ctx.getOutputStream().writeUInt16(offset, c.byteOrder(), (int) crc);
+                break;
+            case CRC32:
+                ctx.getOutputStream().writeUInt32(offset, c.byteOrder(), crc);
+                break;
+        }
+    }
+
+    private long readChecksum(byte[] bytes, int offset, Checksum c) {
+        switch (c.type()) {
+            case CRC8:
+                return bytes[offset] & 0xFFL;
+            case CRC16:
+                if (c.byteOrder() == ByteOrder.LITTLE) {
+                    return (bytes[offset] & 0xFF) | ((bytes[offset + 1] & 0xFF) << 8);
+                } else {
+                    return ((bytes[offset] & 0xFF) << 8) | (bytes[offset + 1] & 0xFF);
+                }
+            case CRC32:
+                if (c.byteOrder() == ByteOrder.LITTLE) {
+                    return (bytes[offset] & 0xFFL) |
+                            ((bytes[offset + 1] & 0xFFL) << 8) |
+                            ((bytes[offset + 2] & 0xFFL) << 16) |
+                            ((bytes[offset + 3] & 0xFFL) << 24);
+                } else {
+                    return ((bytes[offset] & 0xFFL) << 24) |
+                            ((bytes[offset + 1] & 0xFFL) << 16) |
+                            ((bytes[offset + 2] & 0xFFL) << 8) |
+                            (bytes[offset + 3] & 0xFFL);
+                }
+        }
+        return 0;
+    }
+
+    @Override
+    public long getCode() {
+        return 0;
+    }
+}

--- a/src/main/java/org/indunet/fastproto/pipeline/Pipeline.java
+++ b/src/main/java/org/indunet/fastproto/pipeline/Pipeline.java
@@ -31,9 +31,12 @@ import java.util.Arrays;
  */
 public abstract class Pipeline<T> {
     protected static Class<? extends Pipeline>[] decodeFlowClasses = new Class[] {
-            DecodeFlow.class};
+            DecodeFlow.class,
+            ChecksumFlow.class
+    };
     protected static Class<? extends Pipeline>[] encodeFlowClasses = new Class[] {
             EncodeFlow.class,
+            ChecksumFlow.class
     };
 
     Pipeline<T> next = null;
@@ -85,11 +88,8 @@ public abstract class Pipeline<T> {
     protected static Pipeline encodePipeline;
 
     static {
-        // remove unnecessary flow.
-        decodePipeline = new DecodeFlow();
-
-        // remove unnecessary flow.
-        encodePipeline = new EncodeFlow();
+        decodePipeline = Pipeline.create(decodeFlowClasses);
+        encodePipeline = Pipeline.create(encodeFlowClasses);
     }
 
     protected static Pipeline<ValidatorContext> validateFlow;

--- a/src/test/java/org/indunet/fastproto/checksum/Checksum16AnnotationObject.java
+++ b/src/test/java/org/indunet/fastproto/checksum/Checksum16AnnotationObject.java
@@ -1,0 +1,29 @@
+package org.indunet.fastproto.checksum;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.indunet.fastproto.ByteOrder;
+import org.indunet.fastproto.annotation.Checksum;
+import org.indunet.fastproto.annotation.UInt16Type;
+import org.indunet.fastproto.annotation.UInt8Type;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Checksum16AnnotationObject {
+    @UInt8Type(offset = 0)
+    int b1;
+    @UInt8Type(offset = 1)
+    int b2;
+    @UInt8Type(offset = 2)
+    int b3;
+    @UInt8Type(offset = 3)
+    int b4;
+    @UInt8Type(offset = 4)
+    int b5;
+
+    @UInt16Type(offset = 5, byteOrder = ByteOrder.LITTLE)
+    @Checksum(offset = 0, type = Checksum.Type.CRC16, byteOrder = ByteOrder.LITTLE)
+    int crc;
+}

--- a/src/test/java/org/indunet/fastproto/checksum/Checksum32AnnotationObject.java
+++ b/src/test/java/org/indunet/fastproto/checksum/Checksum32AnnotationObject.java
@@ -1,0 +1,29 @@
+package org.indunet.fastproto.checksum;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.indunet.fastproto.ByteOrder;
+import org.indunet.fastproto.annotation.Checksum;
+import org.indunet.fastproto.annotation.UInt32Type;
+import org.indunet.fastproto.annotation.UInt8Type;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Checksum32AnnotationObject {
+    @UInt8Type(offset = 0)
+    int b1;
+    @UInt8Type(offset = 1)
+    int b2;
+    @UInt8Type(offset = 2)
+    int b3;
+    @UInt8Type(offset = 3)
+    int b4;
+    @UInt8Type(offset = 4)
+    int b5;
+
+    @UInt32Type(offset = 5, byteOrder = ByteOrder.BIG)
+    @Checksum(offset = 0, type = Checksum.Type.CRC32, byteOrder = ByteOrder.BIG)
+    long crc;
+}

--- a/src/test/java/org/indunet/fastproto/checksum/ChecksumAnnotationObject.java
+++ b/src/test/java/org/indunet/fastproto/checksum/ChecksumAnnotationObject.java
@@ -1,0 +1,27 @@
+package org.indunet.fastproto.checksum;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.indunet.fastproto.annotation.Checksum;
+import org.indunet.fastproto.annotation.UInt8Type;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChecksumAnnotationObject {
+    @UInt8Type(offset = 0)
+    int b1;
+    @UInt8Type(offset = 1)
+    int b2;
+    @UInt8Type(offset = 2)
+    int b3;
+    @UInt8Type(offset = 3)
+    int b4;
+    @UInt8Type(offset = 4)
+    int b5;
+
+    @UInt8Type(offset = 5)
+    @Checksum(offset = 0, type = Checksum.Type.CRC8)
+    int crc;
+}

--- a/src/test/java/org/indunet/fastproto/checksum/ChecksumAnnotationTest.java
+++ b/src/test/java/org/indunet/fastproto/checksum/ChecksumAnnotationTest.java
@@ -1,0 +1,43 @@
+package org.indunet.fastproto.checksum;
+
+import org.indunet.fastproto.FastProto;
+import org.indunet.fastproto.annotation.Checksum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ChecksumAnnotationTest {
+    @Test
+    public void testObjectCrc8() {
+        ChecksumAnnotationObject obj = new ChecksumAnnotationObject(
+                0x31, 0x32, 0x33, 0x34, 0x35, 0xCB);
+        byte[] bytes = FastProto.encode(obj, 6);
+        long crc = ChecksumUtils.calculate(bytes, 0, 5, Checksum.Type.CRC8);
+        assertEquals(bytes[5] & 0xFF, crc);
+    }
+
+    @Test
+    public void testObjectCrc16() {
+        Checksum16AnnotationObject obj = new Checksum16AnnotationObject(
+                0x31, 0x32, 0x33, 0x34, 0x35, 0);
+        byte[] bytes = FastProto.encode(obj, 7);
+        long crc = ChecksumUtils.calculate(bytes, 0, 5, Checksum.Type.CRC16);
+        int low = bytes[5] & 0xFF;
+        int high = bytes[6] & 0xFF;
+        int actual = low | (high << 8);
+        assertEquals((int) crc, actual);
+    }
+
+    @Test
+    public void testObjectCrc32() {
+        Checksum32AnnotationObject obj = new Checksum32AnnotationObject(
+                0x31, 0x32, 0x33, 0x34, 0x35, 0L);
+        byte[] bytes = FastProto.encode(obj, 9);
+        long crc = ChecksumUtils.calculate(bytes, 0, 5, Checksum.Type.CRC32);
+        long actual = ((bytes[5] & 0xFFL) << 24) |
+                ((bytes[6] & 0xFFL) << 16) |
+                ((bytes[7] & 0xFFL) << 8) |
+                (bytes[8] & 0xFFL);
+        assertEquals(crc, actual);
+    }
+}

--- a/src/test/java/org/indunet/fastproto/checksum/ChecksumUtilsTest.java
+++ b/src/test/java/org/indunet/fastproto/checksum/ChecksumUtilsTest.java
@@ -1,0 +1,52 @@
+package org.indunet.fastproto.checksum;
+
+import org.indunet.fastproto.ByteOrder;
+import org.indunet.fastproto.annotation.Checksum;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ChecksumUtilsTest {
+    @Test
+    public void testCrc8LittleAndBig() {
+        byte[] data = {0x31,0x32,0x33,0x34,0x35};
+        int crc = new CRC8().calculate(data);
+        byte[] little = {(byte) crc};
+        byte[] big = {(byte) crc};
+        assertEquals(0xCB, crc);
+        assertArrayEquals(new byte[]{(byte)0xCB}, little);
+        assertArrayEquals(new byte[]{(byte)0xCB}, big);
+    }
+    @Test
+    public void testCrc16LittleAndBig() {
+        byte[] data = {0x31,0x32,0x33,0x34,0x35};
+        int crc = CRC16.CRC16_IBM_INITIAL_VALUE;
+        crc = new CRC16().calculate(data);
+        byte[] little = {(byte) crc, (byte) (crc >>> 8)};
+        byte[] big = {(byte) (crc >>> 8), (byte) crc};
+        assertEquals(0xA455, crc);
+        assertArrayEquals(new byte[]{(byte)0x55,(byte)0xA4}, little);
+        assertArrayEquals(new byte[]{(byte)0xA4,(byte)0x55}, big);
+    }
+
+    @Test
+    public void testCrc32LittleAndBig() {
+        byte[] data = {0x31,0x32,0x33,0x34,0x35};
+        int crc = new CRC32().calculate(data);
+        byte[] little = {(byte)crc,(byte)(crc>>>8),(byte)(crc>>>16),(byte)(crc>>>24)};
+        byte[] big = {(byte)(crc>>>24),(byte)(crc>>>16),(byte)(crc>>>8),(byte)crc};
+        assertEquals(0xCBF53A1C, crc);
+        assertArrayEquals(new byte[]{(byte)0x1C,(byte)0x3A,(byte)0xF5,(byte)0xCB}, little);
+        assertArrayEquals(new byte[]{(byte)0xCB,(byte)0xF5,(byte)0x3A,(byte)0x1C}, big);
+    }
+
+    @Test
+    public void testCalculateRange() {
+        byte[] data = {1,2,3,4,5};
+        long crc8 = ChecksumUtils.calculate(data,0,5, Checksum.Type.CRC8);
+        long crc16 = ChecksumUtils.calculate(data,0,5, Checksum.Type.CRC16);
+        long crc32 = ChecksumUtils.calculate(data,0,5, Checksum.Type.CRC32);
+        assertEquals(new CRC8().calculate(data) & 0xFF, crc8);
+        assertEquals(new CRC16().calculate(data) & 0xFFFF, crc16);
+        assertEquals(new CRC32().calculate(data) & 0xFFFFFFFFL, crc32);
+    }
+}


### PR DESCRIPTION
## Summary
- integrate `ChecksumFlow` into the default encode/decode pipelines using `Pipeline.create`
- update default flow class arrays to include `ChecksumFlow`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582858e83c8324b12418f2b9aabf09