### PR TITLE
Resolve generic Pipeline arrays

### DIFF
--- a/src/main/java/org/indunet/fastproto/pipeline/Pipeline.java
+++ b/src/main/java/org/indunet/fastproto/pipeline/Pipeline.java
@@ -30,11 +30,11 @@ import java.util.Arrays;
  * @since 1.7.0
  */
 public abstract class Pipeline<T> {
-    protected static Class<? extends Pipeline>[] decodeFlowClasses = new Class[] {
+    protected static Class<? extends Pipeline<PipelineContext>>[] decodeFlowClasses = new Class[]{
             DecodeFlow.class,
             ChecksumFlow.class
     };
-    protected static Class<? extends Pipeline>[] encodeFlowClasses = new Class[] {
+    protected static Class<? extends Pipeline<PipelineContext>>[] encodeFlowClasses = new Class[]{
             EncodeFlow.class,
             ChecksumFlow.class
     };


### PR DESCRIPTION
## Summary
- fix `decodeFlowClasses` and `encodeFlowClasses` generic types so Pipeline.create() infers `PipelineContext`

## Testing
- `mvn -q -DskipTests=true package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_685ab15c8d4483249e368a0d639a0d0b